### PR TITLE
 [정영재]로그아웃,회원수정v1(re)

### DIFF
--- a/src/main/java/com/cos/lecturereviewapp/config/WebMvcConfig.java
+++ b/src/main/java/com/cos/lecturereviewapp/config/WebMvcConfig.java
@@ -1,0 +1,21 @@
+package com.cos.lecturereviewapp.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.cos.lecturereviewapp.handler.SessionInterceptor;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer{
+	public WebMvcConfig() {
+		
+	}
+	
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(new SessionInterceptor())
+			.addPathPatterns("/user/**");
+	}
+	
+}

--- a/src/main/java/com/cos/lecturereviewapp/handler/SessionInterceptor.java
+++ b/src/main/java/com/cos/lecturereviewapp/handler/SessionInterceptor.java
@@ -7,7 +7,6 @@ import javax.servlet.http.HttpSession;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import com.cos.lecturereviewapp.domain.user.User;
-import com.cos.lecturereviewapp.handler.ex.MyNotFoundException;
 
 
 public class SessionInterceptor implements HandlerInterceptor{

--- a/src/main/java/com/cos/lecturereviewapp/service/user/UserServiceImpl.java
+++ b/src/main/java/com/cos/lecturereviewapp/service/user/UserServiceImpl.java
@@ -27,6 +27,9 @@ public class UserServiceImpl implements UserService {
 		User userEntity = userRepository.findById(principal.getId())
 				.orElseThrow(()-> new MyAsyncNotFoundException("회원정보를 찾을 수 없습니다."));
 		userEntity.setEmail(dto.getEmail());
+		userEntity.setPhone(dto.getPhone());
+		//userEntity.setPassword(dto.getPassword());
+		
 	}
 
 	@Override

--- a/src/main/java/com/cos/lecturereviewapp/web/UserController.java
+++ b/src/main/java/com/cos/lecturereviewapp/web/UserController.java
@@ -39,8 +39,9 @@ public class UserController {
 	
 	
 	
-	// 영재 - 회원수정 인증
+
 	
+	// 영재 - 회원 수정 @PutMapping("/user/{id}")  
 	@PutMapping("/user/{id}")
 	public @ResponseBody CMRespDto<String> upserUpdate(@PathVariable int id, @Valid @RequestBody UserUpdateDto dto,
 			BindingResult bindingResult) {
@@ -65,22 +66,30 @@ public class UserController {
 		
 		// 세션 동기화 해주는 부분
 		principal.setEmail(dto.getEmail());
+		principal.setPhone(dto.getPhone());
+		//principal.setPassword(dto.getPassword());
 		session.setAttribute("principal", principal); // 세션 값 변경
 
 		return new CMRespDto<>(1, "성공", null);
 	}
 	
-	// 영재 - 회원 수정 @PutMapping("/user/{id}")  // 인증과 수정이 둘다 put이니 에러가남 빈이
+	// 영재 - 회원 수정 페이지 이동 @GetMapping("/user/{id}")  return "user/updateForm";
+	
 	@GetMapping("/user/{id}")
 	public String userInfo(@PathVariable int id) {
 		// 기본은 userRepository.findById(id) 디비에서 가져와야 함.
 		// 편법은 세션값을 가져올 수도 있다.
-
+		
 		return "user/updateForm";
 	}
-	// 영재 - 회원 수정 페이지 이동 @GetMapping("/user/{id}")  return "user/updateForm";
 	
 	// 영재 - 로그아웃 @GetMapping("/logout")
+	
+	@GetMapping("/logout")
+	public String logout() {
+		session.invalidate(); // 세션 무효화 (jsessionId에 있는 값을 비우는 것)
+		return "redirect:/"; 
+	}
 	
 	// 영재 - 로그인 @PostMapping("/login")
 	@PostMapping("/login")

--- a/src/main/java/com/cos/lecturereviewapp/web/dto/UserUpdateDto.java
+++ b/src/main/java/com/cos/lecturereviewapp/web/dto/UserUpdateDto.java
@@ -11,8 +11,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class UserUpdateDto {
 	@NotBlank
-	private String phone;
 	private String email;
-
+	private String phone;
+	private String password;
 	
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,7 +16,7 @@ spring:
   jpa:
     open-in-view: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
       naming:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
     show-sql: true    

--- a/src/main/webapp/WEB-INF/views/layout/header.jsp
+++ b/src/main/webapp/WEB-INF/views/layout/header.jsp
@@ -63,7 +63,7 @@ header {
 						<div class="collapse navbar-collapse" id="collapsibleNavbar">
 				<ul class="navbar-nav">
 					<li class="nav-item"><a class="nav-link" href="/user/${sessionScope.principal.id}">회원정보수정</a></li>				
-					<li class="nav-item"><a class="nav-link" href="/user/${sessionScope.principal.id}">로그아웃</a></li>				
+					<li class="nav-item"><a class="nav-link" href="/logout">로그아웃</a></li>				
 						</ul>
 						</div>
 				</c:otherwise>

--- a/src/main/webapp/WEB-INF/views/user/deleteForm.jsp
+++ b/src/main/webapp/WEB-INF/views/user/deleteForm.jsp
@@ -64,7 +64,8 @@ background:none;
 <!-- Custom styles for this template -->
 <link href="/assets/dist/css/signin.css" rel="stylesheet">
 </head>
-
+<br>
+<br>
 <body class="text-center">
 <div class="form-container">
 	<div class="container">

--- a/src/main/webapp/WEB-INF/views/user/updateForm.jsp
+++ b/src/main/webapp/WEB-INF/views/user/updateForm.jsp
@@ -118,23 +118,23 @@ nav {
 </style>
 
 <div class="form-container">
-	<form onsubmit="update(event, ${sessionScope.principal.id})">
 		<h3>회원 정보 수정</h3>
 		<p>양식에 맞추어 수정할 내용을 입력해주세요.</p>
+	<form onsubmit="userUpdate(event, ${sessionScope.principal.id})">
 		<div class="form-group">
 			<input type="text" class="form-control" required placeholder="아이디" readonly="readonly" value="${sessionScope.principal.username}">
 		</div>
 		<div class="form-group">
-			<input type="password" class="form-control" required placeholder="비밀번호" readonly="readonly" >
+			<input type="password" class="form-control" id="password" required placeholder="비밀번호"  value="${sessionScope.principal.password}">
 		</div>
 		<div class="form-group">
 			<input type="text" class="form-control" required placeholder="이름" readonly="readonly" value="${sessionScope.principal.name}">
 		</div>
 		<div class="form-group">
-			<input type="text" class="form-control" required placeholder="이메일" value="${sessionScope.principal.email}" >
+			<input type="email" id="email" class="form-control" required placeholder="이메일" value="${sessionScope.principal.email}" >
 		</div>
 		<div class="form-group">
-			<input type="text" class="form-control" required placeholder="전화번호" value="${sessionScope.principal.phone}" >
+			<input type="text"  id="phone"  class="form-control" required placeholder="전화번호" value="${sessionScope.principal.phone}" >
 		</div>
 		<nav>
 			<button id="btn1" type="submit">수정하기</button>
@@ -144,6 +144,34 @@ nav {
 	</form>
 </div>
 
+<script>
+async function userUpdate(event, id){ 
+	   event.preventDefault();
+
+	   let userUpdateDto = {
+			   email: document.querySelector("#email").value,
+			   phone: document.querySelector("#phone").value,
+			 //  password: document.querySelector("#password").value
+	   };
+		
+		let response = await fetch("http://localhost:8080/user/"+id, {
+			method: "put",
+			body: JSON.stringify(userUpdateDto),
+			headers: {
+				"Content-Type": "application/json; charset=utf-8"
+			}
+		});
+		
+		let parseResponse = await response.json();
+
+		if(parseResponse.code == 1){
+			alert("업데이트 성공");
+			location.href = "/";
+		}else{
+			alert("업데이트 실패 : "+parseResponse.msg);
+		}
+}
+</script>
 
 <%@ include file="../layout/footer.jsp"%>
 


### PR DESCRIPTION
1) 회원수정

1. 조인폼의 class를 password로 변경 
2. UserUpdateDto 추가
3. UserServiceImpl에 userUpdate 란 추가
4. UserController에 userUpdate 추가 
5. CMRespDto 추가
6. SessionInterceptor 추가


* UserController에 수정과 인증둘다 put 일경우 서버가 돌아가지 않음 왜인지 알아보삼

2) 헤더

1. 헤더에 choose 태그를 추가해서 로그인후와 전의 노출이 다르게 만들어줌
2. 회원정보 수정과 로그아웃에 세션스코프 제이슨을 걸어줌

기타)

1. 로그인폼에 <br> 태그 추가
2. yml 의 jpa create로 변경
3. header의 로고를클릭하면 / 로 가기로 수정